### PR TITLE
OPS-2739 Add Dockerfile with basic tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+---
+
+###
+### Travis settings
+###
+sudo: required
+services:
+  - docker
+
+
+###
+### Install requirements
+###
+install:
+  # Get newer docker version
+  - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get update; then break; else i=$((i+1)); fi done
+  - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce; then break; else i=$((i+1)); fi done
+  - docker version
+
+
+###
+### Build and test Docker images
+###
+before_script:
+  - make build
+  - make test
+
+
+###
+### Push Docker images
+###
+script:
+  # Push to docker hub on success
+  - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+      make login DOCKER_USER="${DOCKER_USER}" DOCKER_PASS="${DOCKER_PASS}";
+      if [ -n "${TRAVIS_TAG}" ]; then
+        make push TAG="${TRAVIS_TAG}";
+      elif [ "${TRAVIS_BRANCH}" == "master" ]; then
+        make push;
+      elif [[ ${TRAVIS_BRANCH} =~ ^(release-[.0-9]+)$ ]]; then
+        make push TAG="${TRAVIS_BRANCH}";
+      elif [[ ${TRAVIS_BRANCH} =~ ^(OPS-.*)$ ]]; then
+        make push TAG="${TRAVIS_BRANCH}";
+      else
+        echo "Skipping branch ${TRAVIS_BRANCH}";
+      fi
+    else
+      echo "Skipping push on PR";
+    fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+FROM debian:stretch-slim
+MAINTAINER "Patrick Plocke" <patrick.plocke@flaconi.de>
+
+
+ENV BUILD_DEPS \
+	curl \
+	unzip \
+	xz-utils
+
+ENV RUN_DEPS \
+	ca-certificates
+
+
+###
+### Depenencies
+###
+RUN set -ex \
+	&& DEBIAN_FRONTEND=noninteractive \
+	&& apt-get update -qq \
+	&& apt-get install -qq -y --no-install-recommends --no-install-suggests -y \
+		${BUILD_DEPS} \
+		${RUN_DEPS} \
+	&& DEBIAN_FRONTEND=noninteractive apt-get purge -qq -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+	&& rm -rf /var/lib/apt/lists/*
+
+
+###
+### NodeJS
+###
+ENV NODE_DOWNLOAD_URL="https://nodejs.org/en/download/"
+RUN set -ex \
+	&& NODE_DOWNLOAD_XS="$( \
+		curl -sSL https://nodejs.org/en/download/ \
+			| grep -Eo 'https://.+node-v[.0-9]+-linux-x64\.tar\.xz' \
+	)" \
+	&& curl -sS "${NODE_DOWNLOAD_XS}" > /tmp/node.tar.xz \
+	&& cd /tmp \
+	&& tar -xf node.tar.xz \
+	&& rm node.tar.xz \
+	&& mv node* /usr/local/node \
+	&& ln -s /usr/local/node/bin/node /usr/local/bin/node \
+	&& ln -s /usr/local/node/bin/npm /usr/local/bin/npm \
+	&& ln -s /usr/local/node/bin/npx /usr/local/bin/npx
+
+
+
+###
+### Sonar Scanner
+###
+ENV SONAR_DOWNLOAD_URL="https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner"
+RUN set -ex \
+	&& SONAR_DOWNLOAD_ZIP="$( \
+		curl -sSL  https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner \
+		| grep -Eo 'https://.*?sonar-scanner-cli-[.0-9]+-linux\.zip' \
+	)" \
+	&& curl -sSL "${SONAR_DOWNLOAD_ZIP}" > /tmp/sonar-scanner-cli.zip \
+	&& cd /tmp \
+	&& unzip sonar-scanner-cli.zip \
+	&& rm sonar-scanner-cli.zip \
+	&& mv /tmp/sonar-scanner-* /usr/local/sonar-scanner \
+	&& ln -s /usr/local/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner
+
+
+###
+### Volume & Workdir
+###
+VOLUME /sonar
+WORKDIR /sonar
+
+
+###
+### Default entrypoint
+###
+CMD ["--version"]
+ENTRYPOINT ["sonar-scanner"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ENV BUILD_DEPS \
 	xz-utils
 
 ENV RUN_DEPS \
-	ca-certificates
+	ca-certificates \
+	jq
 
 
 ###
@@ -59,6 +60,12 @@ RUN set -ex \
 	&& rm sonar-scanner-cli.zip \
 	&& mv /tmp/sonar-scanner-* /usr/local/sonar-scanner \
 	&& ln -s /usr/local/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner
+
+
+###
+### SonarCube Result fetcher
+###
+COPY data/sonar-result /usr/local/bin/sonar-result
 
 
 ###

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DIR = .
 FILE = Dockerfile
-IMAGE = "flaconi/docker-sonar-scanner"
+IMAGE = "flaconi/sonar-scanner"
 TAG = latest
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+DIR = .
+FILE = Dockerfile
+IMAGE = "flaconi/docker-sonar-scanner"
+TAG = latest
+
+
+pull:
+	docker pull $(shell grep FROM Dockerfile | sed 's/^FROM//g';)
+
+build:
+	docker build -t $(IMAGE) -f $(DIR)/$(FILE) $(DIR)
+
+rebuild: pull
+	docker build --no-cache -t $(IMAGE) -f $(DIR)/$(FILE) $(DIR)
+
+test:
+	./tests/test.sh $(IMAGE)
+
+tag:
+	docker tag $(IMAGE) $(IMAGE):$(TAG)
+
+login:
+ifndef DOCKER_USER
+	$(error DOCKER_USER must either be set via environment or parsed as argument)
+endif
+ifndef DOCKER_PASS
+	$(error DOCKER_PASS must either be set via environment or parsed as argument)
+endif
+	yes | docker login --username $(DOCKER_USER) --password $(DOCKER_PASS)
+
+push:
+	@$(MAKE) tag TAG=$(TAG)
+	docker push $(IMAGE):$(TAG)
+
+enter:
+	docker run --rm --name $(subst /,-,$(IMAGE)) -it --entrypoint=bash $(ARG) $(IMAGE)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/Flaconi/docker-sonar-scanner.svg?branch=master)](https://travis-ci.com/Flaconi/docker-sonar-scanner)
 
-[flaconi/sonar-scanner](https://hub.docker.com/r/flaconi/sonar-scanner/tags)
+[![flaconi/sonar-scanner](https://dockeri.co/image/flaconi/sonar-scanner)](https://hub.docker.com/r/flaconi/sonar-scanner/)
 
 This repository provides the SonarQube Scanner binary for testing against SonarQube or SonarCloud.
 

--- a/data/sonar-result
+++ b/data/sonar-result
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+# --------------------------------------------------------------------------------------------------
+# GLOBALS
+# --------------------------------------------------------------------------------------------------
+CLR_TEST="\033[0;33m"  # Yellow
+CLR_FAIL="\033[0;31m"  # Red
+CLR_OK="\033[0;32m"    # Green
+CLR_RST="\033[m"       # Reset to normal
+
+
+# --------------------------------------------------------------------------------------------------
+# HELPER FUNCTIONS
+# --------------------------------------------------------------------------------------------------
+
+function print_version() {
+	echo "sonarcloud-fetch v0.1"
+}
+
+
+function print_usage() {
+	cat <<'EOF'
+USAGE: sonarcloud-result [-t <token>] [<path>]
+	   sonarcloud-result --help
+	   sonarcloud-result --version
+
+Options
+   -t <token>   (Optional) The SonarCloud Token for authorization
+
+Arguments
+	<path>	  (Optional) The path to the project. Uses current directory if not specified
+EOF
+}
+
+
+# --------------------------------------------------------------------------------------------------
+# SANITY CHECK
+# --------------------------------------------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+	>&2 echo "Error, 'jq' binary required but not found"
+	exit 1
+fi
+
+
+# --------------------------------------------------------------------------------------------------
+# ARGUMENTS
+# --------------------------------------------------------------------------------------------------
+SONARCLOUD_TOKEN=
+
+###
+### Get SonarCloud Token
+###
+while [ ${#} -gt 0 ]; do
+	case "${1}" in
+		# ---- Help / version
+		--version)
+			print_version
+			exit
+			;;
+		--help)
+			print_usage
+			exit
+			;;
+		# ---- Options
+		-t)
+			shift
+			SONARCLOUD_TOKEN="${1}"
+			shift
+			;;
+		# ---- Stop here
+		--) # End of all options
+			shift
+			break
+			;;
+		-*) # Unknown option
+			>&2 echo "Error: Unknown option: ${1}"
+			exit 1
+			;;
+		*)  # No more options
+			break
+			;;
+	esac
+done
+
+
+###
+### Get Path
+###
+
+if [ "${#}" -eq "1" ]; then
+	WORKDIR="${1}"
+elif [ "${#}" -eq "0" ]; then
+	WORKDIR="$( pwd )"
+else
+	>&2 "Error: Too many arguments."
+	exit 1
+fi
+
+
+# --------------------------------------------------------------------------------------------------
+# ENTRYPOINT: Sanity check
+# --------------------------------------------------------------------------------------------------
+
+if [ ! -d "${WORKDIR}" ]; then
+	>&2 "Error, invalid directory"
+	exit 1
+fi
+
+if [ ! -f "${WORKDIR}/.scannerwork/report-task.txt" ]; then
+	>&2 "Error, report-task.txt not found in: ${WORKDIR}/.scannerwork/report-task.txt"
+	exit 1
+fi
+
+
+# --------------------------------------------------------------------------------------------------
+# ENTRYPOINT: Main
+# --------------------------------------------------------------------------------------------------
+
+printf "${CLR_TEST}[TEST]${CLR_RST} Waiting for SonarQube task status "
+
+###
+### Make variables available to this script
+###
+source .scannerwork/report-task.txt
+
+
+###
+### Check remote result in a loop
+###
+max=120; i=0; while [ "${i}" -lt "${max}" ]; do
+	# shellcheck disable=SC2154
+	TASK_RESULT="$( curl -sSu "${SONARCLOUD_TOKEN}:" "${ceTaskUrl}" )"
+	TASK_STATUS="$(echo "${TASK_RESULT}" | jq '.task.status' | sed 's/"//g' )"
+	printf "."
+
+	if [ "${TASK_STATUS}" != "PENDING" ] && [ "${TASK_STATUS}" != "IN_PROGRESS" ]; then
+		break
+	else
+		i=$((i+1))
+	fi
+
+	sleep 1;
+done
+printf "\r${CLR_OK}[OK]${CLR_RST}   Waiting for SonarQube task status\n"
+
+
+###
+### Evaluate Task status
+###
+if [ "${TASK_STATUS}" = "SUCCESS" ]; then
+	printf "${CLR_OK}[OK]${CLR_RST}   SonarQube task status: ${TASK_STATUS}\n"
+else
+	printf "${CLR_FAIL}[FAIL]${CLR_RST} SonarQube task status: ${TASK_STATUS}\n"
+	exit 1
+fi
+
+
+###
+### Evaluate Quality Gate
+###
+QG_RESULT_ID="$( echo "${TASK_RESULT}" | jq '.task.analysisId' | sed 's/"//g' )"
+# shellcheck disable=SC2154
+QG_RESULT="$( curl -sSu "${SONARCLOUD_TOKEN}:" "${serverUrl}/api/qualitygates/project_status?analysisId=${QG_RESULT_ID}" )"
+QG_STATUS="$( echo "${QG_RESULT}" | jq '.projectStatus.status' | sed 's/"//g' )"
+
+if [ "${QG_STATUS}" != "ERROR" ]; then
+	printf "${CLR_OK}[OK]${CLR_RST}   SonarQube Quality Gate: ${QG_STATUS}\n"
+else
+	printf "${CLR_OK}[FAIL]${CLR_RST} SonarQube Quality Gate: ${QG_STATUS}\n"
+	exit 1
+fi

--- a/data/sonar-result
+++ b/data/sonar-result
@@ -25,14 +25,14 @@ function print_version() {
 function print_usage() {
 	cat <<'EOF'
 USAGE: sonarcloud-result [-t <token>] [<path>]
-	   sonarcloud-result --help
-	   sonarcloud-result --version
+       sonarcloud-result --help
+       sonarcloud-result --version
 
 Options
-   -t <token>   (Optional) The SonarCloud Token for authorization
+   -t <token>  (Optional) The SonarCloud Token for authorization
 
 Arguments
-	<path>	  (Optional) The path to the project. Uses current directory if not specified
+   <path>      (Optional) The path to the project. Uses current directory if not specified
 EOF
 }
 
@@ -80,7 +80,7 @@ while [ ${#} -gt 0 ]; do
 			>&2 echo "Error: Unknown option: ${1}"
 			exit 1
 			;;
-		*)  # No more options
+		*) # No more options
 			break
 			;;
 	esac

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+IMAGE="${1}"
+
+docker run --rm "${IMAGE}" --version | grep -E 'SonarQube Scanner [.0-9]+'


### PR DESCRIPTION
# Add Docker for SonarQube Scanner

This PR adds a Dockerfile that creates an image for SonarQube Scanner.

## Todo

* [x] Add working Travis checks: Basic version check to see if `sonar-scanner` binary works
* [x] Push to Dockerhub on success: https://hub.docker.com/r/flaconi/sonar-scanner/tags/
* [x] ~~Ensure all Plugins are already bundled with this image and not pulled on every project lint~~ Won't do atm

## How to build
```bash
make build
```

## How to test
```bash
make test
```

**Update**

* Now being able to auto-push to Dockerhub: https://hub.docker.com/r/flaconi/sonar-scanner/tags/
* Travis checks for sonar-scanner version as a basic test
* Pre-fetching of plugins won't do atm. This introduces around 8-10sec of extra cost for linting